### PR TITLE
fix: 템플릿 선택 시 기본 매핑 설정을 추가하여, 첫 실행 시, 쿼리스트링이 반영되지 않는 문제

### DIFF
--- a/src/renderer/components/SortableStepItem.tsx
+++ b/src/renderer/components/SortableStepItem.tsx
@@ -78,6 +78,20 @@ export const SortableStepItem: React.FC<SortableStepItemProps> = ({
   const handleTemplateSelect = (templateId: string) => {
     const template = httpTemplates.find(t => t.id === templateId);
     if (template) {
+      // Seed default mappings so execution can rely on explicit entries
+      const pathParams = extractPathParams(template.pathTemplate);
+      const queryParams = extractQueryParams(template.queryTemplate);
+
+      const defaultParamMappings = pathParams.reduce<Record<string, { type: 'auto' | 'fixed' | 'skip'; value?: string }>>((acc, param) => {
+        acc[param] = step.params?.paramMappings?.[param] ?? { type: 'auto' };
+        return acc;
+      }, {});
+
+      const defaultQueryMappings = queryParams.reduce<Record<string, { type: 'auto' | 'fixed' | 'skip'; value?: string }>>((acc, param) => {
+        acc[param] = step.params?.queryMappings?.[param] ?? { type: 'auto' };
+        return acc;
+      }, {});
+
       onUpdateStep(step.id, {
         params: {
           ...step.params,
@@ -85,6 +99,8 @@ export const SortableStepItem: React.FC<SortableStepItemProps> = ({
           baseUrl: template.baseUrl,
           pathTemplate: template.pathTemplate,
           queryTemplate: template.queryTemplate,
+          paramMappings: defaultParamMappings,
+          queryMappings: defaultQueryMappings,
           // 출력 타입 초기화
           outputType: step.params?.outputType || 'full',
         }


### PR DESCRIPTION
- 선택된 템플릿의 경로 및 쿼리 템플릿에서 기본 매핑을 추출하여 설정하도록 수정
- 매핑이 명시적으로 존재하도록 하여 실행 시 의존성을 명확히 함